### PR TITLE
GitHub Pages placeholder

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+## Welcome to the CSV library for Salesforce
+
+See [GitHub Pages][1] for info on how to contribute to our documentation.
+
+[1]: https://pages.github.com/


### PR DESCRIPTION
This pr creates a placeholder for GitHub Pages docs to live in the **docs** directory.